### PR TITLE
16 generate documentation for user endpoint by using swagger

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/core": "^9.0.0",
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/swagger": "^6.2.1",
         "@nestjs/typeorm": "^9.0.1",
         "bcrypt": "^5.0.1",
         "joi": "^17.6.2",
@@ -1613,13 +1614,13 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz",
-      "integrity": "sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.2.tgz",
+      "integrity": "sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==",
       "peerDependencies": {
         "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
         "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0",
         "reflect-metadata": "^0.1.12"
       },
       "peerDependenciesMeta": {
@@ -1665,6 +1666,37 @@
       },
       "peerDependencies": {
         "typescript": "^4.3.5"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-6.2.1.tgz",
+      "integrity": "sha512-9M2vkfJHIzLqDZwvM5TEZO0MxRCvIb0xVy0LsmWwxH1lrb0z/4MhU+r2CWDhBtTccVJrKxVPiU2s3T3b9uUJbg==",
+      "dependencies": {
+        "@nestjs/mapped-types": "1.2.2",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "4.15.5"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0",
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -6545,8 +6577,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -8243,6 +8274,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA=="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
@@ -10487,9 +10523,9 @@
       }
     },
     "@nestjs/mapped-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz",
-      "integrity": "sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.2.tgz",
+      "integrity": "sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==",
       "requires": {}
     },
     "@nestjs/platform-express": {
@@ -10515,6 +10551,18 @@
         "fs-extra": "10.1.0",
         "jsonc-parser": "3.0.0",
         "pluralize": "8.0.0"
+      }
+    },
+    "@nestjs/swagger": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-6.2.1.tgz",
+      "integrity": "sha512-9M2vkfJHIzLqDZwvM5TEZO0MxRCvIb0xVy0LsmWwxH1lrb0z/4MhU+r2CWDhBtTccVJrKxVPiU2s3T3b9uUJbg==",
+      "requires": {
+        "@nestjs/mapped-types": "1.2.2",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "4.15.5"
       }
     },
     "@nestjs/testing": {
@@ -14231,8 +14279,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -15501,6 +15548,11 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA=="
     },
     "symbol-observable": {
       "version": "4.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/swagger": "^6.2.1",
     "@nestjs/typeorm": "^9.0.1",
     "bcrypt": "^5.0.1",
     "joi": "^17.6.2",

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpException,
   Post,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { UserDecorator } from '../user/user.decorator';
 import { UserService } from '../user/user.service';
 import { AuthService } from './auth.service';
@@ -13,6 +14,7 @@ import { LoginDto } from './dto/login.dto';
 import { LoginValidatorPipe } from './dto/validation.pipe';
 
 @Controller('auth')
+@ApiTags('Auth')
 export class AuthController {
   constructor(
     private readonly userService: UserService,

--- a/server/src/auth/dto/login.dto.ts
+++ b/server/src/auth/dto/login.dto.ts
@@ -1,4 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class LoginDto {
+  @ApiProperty({
+    example: 'chadwickboseman@gmail.com',
+    description: "The user's email",
+  })
   public email: string;
+  @ApiProperty({ description: "The user's first password" })
   public password: string;
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,8 +1,18 @@
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('Thot API Documentation')
+    .setDescription('The Thot API description')
+    .addTag('api')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(3000);
 }
 bootstrap();

--- a/server/src/note/dto/create-note.dto.ts
+++ b/server/src/note/dto/create-note.dto.ts
@@ -1,5 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CreateNoteDto {
+  @ApiProperty({
+    example: '2022 year in review',
+    description: "The note's title",
+  })
   public title: string;
+  @ApiProperty({ example: 'lorem ipsum', description: "The note's  content" })
   public content: string;
+  @ApiProperty({ example: '1', description: "The note's  projectId" })
   public projectId: number;
 }

--- a/server/src/note/note.controller.ts
+++ b/server/src/note/note.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { ProjectService } from '../project/project.service';
 import { CreateNoteDto } from './dto/create-note.dto';
 import { UpdateNoteDto } from './dto/update-note.dto';
@@ -15,6 +16,7 @@ import { CreateNoteValidatorPipe } from './dto/validation.pipe';
 import { NoteService } from './note.service';
 
 @Controller('note')
+@ApiTags('Note')
 export class NoteController {
   constructor(
     private readonly noteService: NoteService,

--- a/server/src/project/dto/create-project.dto.ts
+++ b/server/src/project/dto/create-project.dto.ts
@@ -1,5 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CreateProjectDto {
+  @ApiProperty({ example: 'roadmap', description: "The project's  name" })
   public name: string;
+  @ApiProperty({
+    example: 'Chadwick',
+    description: "The project's  description",
+  })
   public description?: string;
+  @ApiProperty({ example: 'Chadwick', description: "The project's  userId" })
   public userId: number;
 }

--- a/server/src/project/project.controller.ts
+++ b/server/src/project/project.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { UserService } from '../user/user.service';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
@@ -16,6 +17,7 @@ import { Project } from './entities/project.entity';
 import { ProjectService } from './project.service';
 
 @Controller('project')
+@ApiTags('Project')
 export class ProjectController {
   constructor(
     private readonly projectService: ProjectService,

--- a/server/src/task/dto/create-task.dto.ts
+++ b/server/src/task/dto/create-task.dto.ts
@@ -1,5 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CreateTaskDto {
+  @ApiProperty({
+    example: 'build a portfolio',
+    description: "The task's title",
+  })
   public title: string;
+  @ApiProperty({
+    example: 'create a new website ',
+    description: "The task's  description",
+  })
   public description: string;
+  @ApiProperty({ example: '1', description: "The task's  projectId" })
   public projectId: number;
 }

--- a/server/src/task/task.controller.ts
+++ b/server/src/task/task.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { ProjectService } from '../project/project.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
@@ -15,6 +16,7 @@ import { CreateTaskValidatorPipe } from './dto/validattion.pipe.dto';
 import { TaskService } from './task.service';
 
 @Controller('task')
+@ApiTags('Task')
 export class TaskController {
   constructor(
     private readonly taskService: TaskService,

--- a/server/src/user/dto/create-user.dto.ts
+++ b/server/src/user/dto/create-user.dto.ts
@@ -1,7 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CreateUserDto {
+  @ApiProperty({ example: 'Chadwick', description: "The user's first name" })
   public firstname?: string;
+
+  @ApiProperty({ example: 'Boseman', description: "The user's first lastname" })
   public lastname?: string;
+  @ApiProperty({
+    example: 'chadwickboseman@gmail.com',
+    description: "The user's email",
+  })
   public email?: string;
+  @ApiProperty({ description: "The user's password" })
   public password?: string;
+  @ApiProperty({ description: "The user's confirm_password" })
   public confirm_password?: string;
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -7,12 +7,14 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { CreateUserValidatorPipe } from './dto/validation.pipe';
 import { UserService } from './user.service';
 
 @Controller('user')
+@ApiTags('User')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 


### PR DESCRIPTION
## Generate documentation for user endpoint by using swagger [issue](https://github.com/niemet0502/Thot/issues/16)

### Description 
Generate documentation by using the swagger module 

### Changes
Describe How the solution of feature was implemented 
- install nestjs/swagger package 
- configure it in the main.ts file 
- add ApiTags into each controller 
- add ApiProperty to also generate schema 

### Migrations
NO

### Screen Captures (optional)
![Capture d'écran_20230220_094116](https://user-images.githubusercontent.com/62050249/220069303-57712865-37af-4612-9433-7f209ca3ae6a.png)


### Steps to Test or Reproduce
- Go to http://localhost:3000/api to see the documentation 

