### PR TITLE
14 add typeorm migration

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,11 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "npx typeorm -d dist/db/data-source.js",
+    "migration:generate": "npm run typeorm -- migration:generate",
+    "migration:run": "npm run typeorm -- migration:run",
+    "migration:revert": "npm run typeorm -- migration:revert"
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,28 +4,15 @@ import { DataSource } from 'typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
-import { Session } from './auth/entities/session.entity';
-import { Note } from './note/entities/note.entity';
+import { dataSourceOptions } from './db/data-source';
 import { NoteModule } from './note/note.module';
-import { Project } from './project/entities/project.entity';
 import { ProjectModule } from './project/project.module';
-import { Task } from './task/entities/task.entity';
 import { TaskModule } from './task/task.module';
-import { User } from './user/entities/user.entity';
 import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forRoot({
-      type: 'mysql',
-      host: process.env.DB_HOST,
-      port: parseInt(process.env.DB_PORT, 10),
-      username: process.env.DB_USERNAME || 'root',
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_NAME || 'thot',
-      entities: [User, Project, Session, Note, Task],
-      synchronize: true,
-    }),
+    TypeOrmModule.forRoot(dataSourceOptions),
     UserModule,
     ProjectModule,
     TaskModule,

--- a/server/src/db/data-source.ts
+++ b/server/src/db/data-source.ts
@@ -1,0 +1,17 @@
+import { DataSource, DataSourceOptions } from 'typeorm';
+
+export const dataSourceOptions: DataSourceOptions = {
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT, 10),
+  username: process.env.DB_USERNAME || 'root',
+  password: process.env.DB_PASSWORD,
+  database: 'thotdb',
+  entities: ['dist/**/*entity.js'],
+  migrations: ['dist/db/migrations/*js'],
+  synchronize: false,
+};
+
+const dataSource = new DataSource(dataSourceOptions);
+
+export default dataSource;

--- a/server/src/db/migrations/1677171690352-NewMigration.ts
+++ b/server/src/db/migrations/1677171690352-NewMigration.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NewMigration1677171690352 implements MigrationInterface {
+    name = 'NewMigration1677171690352'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`note\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` text NOT NULL, \`content\` longtext NULL, \`projectId\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`task\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` text NOT NULL, \`isDone\` tinyint NOT NULL DEFAULT 0, \`description\` text NULL, \`isDeleted\` tinyint NOT NULL DEFAULT 0, \`projectId\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`project\` (\`id\` int NOT NULL AUTO_INCREMENT, \`name\` text NOT NULL, \`description\` text NULL, \`isArchive\` tinyint NOT NULL DEFAULT 0, \`userId\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`user\` (\`id\` int NOT NULL AUTO_INCREMENT, \`isConfirm\` tinyint NOT NULL, \`lastname\` text NULL, \`firstname\` text NULL, \`email\` text NOT NULL, \`password\` text NOT NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`session\` (\`id\` int NOT NULL AUTO_INCREMENT, \`token\` text NOT NULL, \`expirationDate\` date NOT NULL, \`userId\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`note\` ADD CONSTRAINT \`FK_62eff03c08cd08ac0cde9bf4c0d\` FOREIGN KEY (\`projectId\`) REFERENCES \`project\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`task\` ADD CONSTRAINT \`FK_3797a20ef5553ae87af126bc2fe\` FOREIGN KEY (\`projectId\`) REFERENCES \`project\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`project\` ADD CONSTRAINT \`FK_7c4b0d3b77eaf26f8b4da879e63\` FOREIGN KEY (\`userId\`) REFERENCES \`user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`session\` ADD CONSTRAINT \`FK_3d2f174ef04fb312fdebd0ddc53\` FOREIGN KEY (\`userId\`) REFERENCES \`user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`session\` DROP FOREIGN KEY \`FK_3d2f174ef04fb312fdebd0ddc53\``);
+        await queryRunner.query(`ALTER TABLE \`project\` DROP FOREIGN KEY \`FK_7c4b0d3b77eaf26f8b4da879e63\``);
+        await queryRunner.query(`ALTER TABLE \`task\` DROP FOREIGN KEY \`FK_3797a20ef5553ae87af126bc2fe\``);
+        await queryRunner.query(`ALTER TABLE \`note\` DROP FOREIGN KEY \`FK_62eff03c08cd08ac0cde9bf4c0d\``);
+        await queryRunner.query(`DROP TABLE \`session\``);
+        await queryRunner.query(`DROP TABLE \`user\``);
+        await queryRunner.query(`DROP TABLE \`project\``);
+        await queryRunner.query(`DROP TABLE \`task\``);
+        await queryRunner.query(`DROP TABLE \`note\``);
+    }
+
+}


### PR DESCRIPTION
## Add typeorm migration support [[Issue]](https://github.com/niemet0502/Thot/issues/14)

### Changes
Describe How the solution of feature was implemented
- added script to the package json for typeorm migration 
- create a separated file for the data-source

### Steps to Test or Reproduce
- Remove all database's tables 
- Generate a new migration by running `npm run migration:migrate -- src/db/migrations/MigrationName` 
- and then run the migration to update the database `npm run migration:run`